### PR TITLE
[SQUASH] Clean up QS tile implementation

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tileimpl/QSTileImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tileimpl/QSTileImpl.java
@@ -14,8 +14,6 @@
 
 package com.android.systemui.qs.tileimpl;
 
-import static androidx.lifecycle.Lifecycle.State.CREATED;
-import static androidx.lifecycle.Lifecycle.State.DESTROYED;
 import static androidx.lifecycle.Lifecycle.State.RESUMED;
 import static androidx.lifecycle.Lifecycle.State.STARTED;
 
@@ -163,7 +161,6 @@ public abstract class QSTileImpl<TState extends State> implements QSTile, Lifecy
         mTmpState = newTileState();
         mQSLogger = host.getQSLogger();
         mUiEventLogger = host.getUiEventLogger();
-        mUiHandler.post(() -> mLifecycle.setCurrentState(CREATED));
     }
 
     protected final void resetStates() {
@@ -443,24 +440,15 @@ public abstract class QSTileImpl<TState extends State> implements QSTile, Lifecy
         if (listening) {
             if (mListeners.add(listener) && mListeners.size() == 1) {
                 if (DEBUG) Log.d(TAG, "handleSetListening true");
+                mLifecycle.setCurrentState(RESUMED);
                 handleSetListening(listening);
-                mUiHandler.post(() -> {
-                    // This tile has been destroyed, the state should not change anymore and we
-                    // should not refresh it anymore.
-                    if (mLifecycle.getCurrentState().equals(DESTROYED)) return;
-                    mLifecycle.setCurrentState(RESUMED);
-                    refreshState(); // Ensure we get at least one refresh after listening.
-                });
+                refreshState(); // Ensure we get at least one refresh after listening.
             }
         } else {
             if (mListeners.remove(listener) && mListeners.size() == 0) {
                 if (DEBUG) Log.d(TAG, "handleSetListening false");
+                mLifecycle.setCurrentState(STARTED);
                 handleSetListening(listening);
-                mUiHandler.post(() -> {
-                    // This tile has been destroyed, the state should not change anymore.
-                    if (mLifecycle.getCurrentState().equals(DESTROYED)) return;
-                    mLifecycle.setCurrentState(STARTED);
-                });
             }
         }
         updateIsFullQs();
@@ -487,14 +475,9 @@ public abstract class QSTileImpl<TState extends State> implements QSTile, Lifecy
         mQSLogger.logTileDestroyed(mTileSpec, "Handle destroy");
         if (mListeners.size() != 0) {
             handleSetListening(false);
-            mListeners.clear();
         }
         mCallbacks.clear();
         mHandler.removeCallbacksAndMessages(null);
-        // This will force it to be removed from all controllers that may have it registered.
-        mUiHandler.post(() -> {
-            mLifecycle.setCurrentState(DESTROYED);
-        });
     }
 
     protected void checkIfRestrictionEnforcedByAdminOnly(State state, String userRestriction) {

--- a/packages/SystemUI/tests/src/com/android/systemui/qs/QSTileHostTest.java
+++ b/packages/SystemUI/tests/src/com/android/systemui/qs/QSTileHostTest.java
@@ -75,7 +75,7 @@ import javax.inject.Provider;
 
 @RunWith(AndroidTestingRunner.class)
 @SmallTest
-@RunWithLooper(setAsMainLooper = true)
+@RunWithLooper
 public class QSTileHostTest extends SysuiTestCase {
 
     private static String MOCK_STATE_STRING = "MockState";

--- a/packages/SystemUI/tests/src/com/android/systemui/qs/external/CustomTileTest.kt
+++ b/packages/SystemUI/tests/src/com/android/systemui/qs/external/CustomTileTest.kt
@@ -47,7 +47,6 @@ import org.mockito.MockitoAnnotations
 
 @SmallTest
 @RunWith(AndroidJUnit4::class)
-@TestableLooper.RunWithLooper(setAsMainLooper = true)
 class CustomTileTest : SysuiTestCase() {
 
     companion object {

--- a/packages/SystemUI/tests/src/com/android/systemui/qs/tileimpl/QSTileImplTest.java
+++ b/packages/SystemUI/tests/src/com/android/systemui/qs/tileimpl/QSTileImplTest.java
@@ -260,16 +260,6 @@ public class QSTileImplTest extends SysuiTestCase {
     }
 
     @Test
-    public void testHandleDestroyLifecycle() {
-        assertNotEquals(DESTROYED, mTile.getLifecycle().getCurrentState());
-        mTile.handleDestroy();
-
-        mTestableLooper.processAllMessages();
-
-        assertEquals(DESTROYED, mTile.getLifecycle().getCurrentState());
-    }
-
-    @Test
     public void testHandleDestroy_log() {
         mTile.handleDestroy();
         verify(mQsLogger).logTileDestroyed(eq(SPEC), anyString());
@@ -318,25 +308,6 @@ public class QSTileImplTest extends SysuiTestCase {
 
         TestableLooper.get(this).processAllMessages();
         assertNotEquals(DESTROYED, mTile.getLifecycle().getCurrentState());
-    }
-
-    @Test
-    public void testRefreshStateAfterDestroyedDoesNotCrash() {
-        mTile.destroy();
-        mTile.refreshState();
-
-        mTestableLooper.processAllMessages();
-    }
-
-    @Test
-    public void testSetListeningAfterDestroyedDoesNotCrash() {
-        Object o = new Object();
-        mTile.destroy();
-
-        mTile.setListening(o, true);
-        mTile.setListening(o, false);
-
-        mTestableLooper.processAllMessages();
     }
 
     private void assertEvent(UiEventLogger.UiEventEnum eventType,

--- a/packages/SystemUI/tests/src/com/android/systemui/qs/tiles/BatterySaverTileTest.kt
+++ b/packages/SystemUI/tests/src/com/android/systemui/qs/tiles/BatterySaverTileTest.kt
@@ -34,7 +34,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 
 @RunWith(AndroidTestingRunner::class)
-@RunWithLooper(setAsMainLooper = true)
+@RunWithLooper
 @SmallTest
 class BatterySaverTileTest : SysuiTestCase() {
 

--- a/packages/SystemUI/tests/src/com/android/systemui/qs/tiles/CastTileTest.java
+++ b/packages/SystemUI/tests/src/com/android/systemui/qs/tiles/CastTileTest.java
@@ -55,7 +55,7 @@ import java.util.List;
 
 
 @RunWith(AndroidTestingRunner.class)
-@TestableLooper.RunWithLooper(setAsMainLooper = true)
+@TestableLooper.RunWithLooper
 @SmallTest
 public class CastTileTest extends SysuiTestCase {
 

--- a/packages/SystemUI/tests/src/com/android/systemui/statusbar/policy/CallbackControllerTest.java
+++ b/packages/SystemUI/tests/src/com/android/systemui/statusbar/policy/CallbackControllerTest.java
@@ -23,12 +23,10 @@ import static org.mockito.Mockito.verify;
 import android.testing.AndroidTestingRunner;
 import android.testing.TestableLooper.RunWithLooper;
 
-import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.Lifecycle.Event;
 import androidx.lifecycle.LifecycleEventObserver;
 import androidx.lifecycle.LifecycleOwner;
-import androidx.lifecycle.LifecycleRegistry;
 import androidx.test.filters.SmallTest;
 
 import com.android.systemui.SysuiTestCase;
@@ -76,34 +74,6 @@ public class CallbackControllerTest extends SysuiTestCase {
         // move to pause state and make sure the callback gets unregistered.
         observer.getValue().onStateChanged(owner, Event.ON_PAUSE);
         verify(controller).removeCallback(eq(callback));
-    }
-
-    @Test
-    public void testCallbackIsRemovedOnDestroy() {
-        SimpleLifecycleOwner owner = new SimpleLifecycleOwner();
-
-        Object callback = new Object();
-        Controller controller = mock(Controller.class);
-        controller.observe(owner, callback);
-
-        owner.setState(Lifecycle.State.RESUMED);
-        verify(controller).addCallback(callback);
-
-        owner.setState(Lifecycle.State.DESTROYED);
-        verify(controller).removeCallback(callback);
-    }
-
-    private static class SimpleLifecycleOwner implements LifecycleOwner {
-        LifecycleRegistry mLifecycle = new LifecycleRegistry(this);
-        @NonNull
-        @Override
-        public Lifecycle getLifecycle() {
-            return mLifecycle;
-        }
-
-        public void setState(Lifecycle.State state) {
-            mLifecycle.setCurrentState(state);
-        }
     }
 
     private static class Controller implements CallbackController<Object> {


### PR DESCRIPTION
Revert "setCurrentState(DESTROYED) called from main thread"

This reverts commit f027d2230eb5e63701c8417e693557682964fc80.

Revert "Enforce setCurrentState calls are on main thread"

This reverts commit b4bf246438640e5ec3425a0a44d82f9ce651d3cc.

Revert "QSTileImpl is set to DESTROYED when handleDestroy"

This reverts commit 0d0e304828ca6d00de70203fbe45fe2d53669336.