### PR TITLE
SystemUI: Add simple fade filter to the media artwork [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5743,6 +5743,14 @@ public final class Settings {
          */
         public static final String ARTWORK_MEDIA_BACKGROUND = "artwork_media_background";
 
+	/**
+         * The fade level of Artwork on background media notification
+         * requires ARTWORK_MEDIA_BACKGROUND to be enabled
+         * @hide
+         */
+        public static final String ARTWORK_MEDIA_FADE_LEVEL = "artwork_media_fade_level";
+
+
         /**
          * Keys we no longer back up under the current schema, but want to continue to
          * process when restoring historical backup datasets.

--- a/packages/SystemUI/src/com/android/systemui/media/MediaControlPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/media/MediaControlPanel.java
@@ -44,6 +44,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.constraintlayout.widget.ConstraintSet;
 
+import com.android.internal.graphics.ColorUtils;
 import com.android.settingslib.Utils;
 import com.android.settingslib.widget.AdaptiveIcon;
 import com.android.systemui.R;
@@ -235,6 +236,9 @@ public class MediaControlPanel {
 
         boolean backgroundArtwork = Settings.System.getInt(mContext.getContentResolver(),
                 Settings.System.ARTWORK_MEDIA_BACKGROUND, 0) == 1;
+        int artworkFadeLevel = Settings.System.getInt(mContext.getContentResolver(),
+                Settings.System.ARTWORK_MEDIA_FADE_LEVEL, 30);
+
         ImageView backgroundImage = mViewHolder.getPlayer().findViewById(R.id.bg_album_art);
 
         mViewHolder.getPlayer().setBackgroundTintList(
@@ -268,6 +272,11 @@ public class MediaControlPanel {
                         backgroundImage.getHeight(), mAlbumArtRadius);
                 }
             });
+            if (backgroundArtwork) {
+                int extraTint = ColorUtils.setAlphaComponent(mBackgroundColor, artworkFadeLevel * 255 / 100);
+                extraTint = ColorUtils.blendARGB(extraTint, android.graphics.Color.BLACK, Math.min(artworkFadeLevel / 100f, 0.5f));
+                backgroundImage.setColorFilter(extraTint, android.graphics.PorterDuff.Mode.SRC_ATOP);
+            }
         }
         setVisibleAndAlpha(collapsedSet, R.id.bg_album_art, backgroundArtwork);
         setVisibleAndAlpha(expandedSet, R.id.bg_album_art, backgroundArtwork);


### PR DESCRIPTION
Some artworks may have a bright colors that will makes the title and
other elements obscured, lets add some color filter that will fade the
album art with already-existing background color for better accessibility.

Signed-off-by: Nauval Rizky <enuma.alrizky@gmail.com>